### PR TITLE
Add namespaces option

### DIFF
--- a/modules/faasd-module.nix
+++ b/modules/faasd-module.nix
@@ -56,92 +56,127 @@ in
         example = "/etc/nixos/faasd-basic-aurh-password";
       };
     };
+
+    namespaces = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Openfaas function namespaces.
+        Namespaces listed here will be created of they do not exist and labeled
+        with `openfaas=true`.
+      '';
+      example = [ "dev" ];
+    };
   };
 
-  config = mkIf cfg.enable {
-    networking.firewall.trustedInterfaces = [ "openfaas0" ];
+  config = mkMerge [
+    (mkIf cfg.enable {
+      networking.firewall.trustedInterfaces = [ "openfaas0" ];
 
-    boot.kernel.sysctl = {
-      "net.ipv4.conf.all.forwarding" = 1;
-    };
-
-    services.faasd.containers = coreServices.services;
-
-    virtualisation.containerd.enable = true;
-
-    systemd.tmpfiles.rules = [
-      "d /opt/cni/bin 0755 root root -"
-      "d /usr/local/bin 0755 root root -"
-      "d '/var/lib/faasd'"
-      "d '/var/lib/faasd-provider'"
-    ];
-
-    systemd.services.faasd-init = {
-      script = ''
-        # Link cni-plugins
-        ln -fs ${pkgs.cni-plugins}/bin/* /opt/cni/bin
-
-        # Link faasd binary
-        ln -fs "${cfg.package}/bin/faasd" "/usr/local/bin/faasd"
-
-        # Set basic-auth user and password
-        mkdir -p /var/lib/faasd/secrets
-        ${if cfg.basicAuth.passwordFile != null then
-          ''ln -fs ${cfg.basicAuth.passwordFile} /var/lib/faasd/secrets/basic-auth-password''
-        else
-          ''
-            if [ ! -e "/var/lib/faasd/secrets/basic-auth-password" ] ; then
-              (head -c 12 /dev/urandom | ${pkgs.perl}/bin/shasum | cut -d' ' -f1) > /var/lib/faasd/secrets/basic-auth-password
-            fi
-          ''
-        }
-        echo ${cfg.basicAuth.user} > /var/lib/faasd/secrets/basic-auth-user
-
-        ln -fs "${cfg.package}/installation/prometheus.yml" "/var/lib/faasd/prometheus.yml"
-        ln -fs "${cfg.package}/installation/resolv.conf" "/var/lib/faasd/resolv.conf"
-      '';
-
-      before = [ "faasd-provider.service" "faasd.service" ];
-      wantedBy = [ "multi-user.target" ];
-
-      serviceConfig = {
-        Type = "oneshot";
+      boot.kernel.sysctl = {
+        "net.ipv4.conf.all.forwarding" = 1;
       };
-    };
 
-    systemd.services.faasd-provider = {
-      description = "faasd-provider";
-      after = [ "network.service" "firewall.service" ];
-      wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.iptables ];
+      services.faasd.containers = coreServices.services;
 
-      serviceConfig = {
-        MemoryLimit = "500M";
-        Restart = "on-failure";
-        RestartSec = "10s";
-        Environment = [ "basic_auth=true" "secret_mount_path=/var/lib/faasd/secrets" ];
-        ExecStart = "${cfg.package}/bin/faasd provider";
-        WorkingDirectory = "/var/lib/faasd-provider";
+      virtualisation.containerd.enable = true;
+
+      systemd.tmpfiles.rules = [
+        "d /opt/cni/bin 0755 root root -"
+        "d /usr/local/bin 0755 root root -"
+        "d '/var/lib/faasd'"
+        "d '/var/lib/faasd-provider'"
+      ];
+
+      systemd.services.faasd-init = {
+        script = ''
+          # Link cni-plugins
+          ln -fs ${pkgs.cni-plugins}/bin/* /opt/cni/bin
+
+          # Link faasd binary
+          ln -fs "${cfg.package}/bin/faasd" "/usr/local/bin/faasd"
+
+          # Set basic-auth user and password
+          mkdir -p /var/lib/faasd/secrets
+          ${if cfg.basicAuth.passwordFile != null then
+            ''ln -fs ${cfg.basicAuth.passwordFile} /var/lib/faasd/secrets/basic-auth-password''
+          else
+            ''
+              if [ ! -e "/var/lib/faasd/secrets/basic-auth-password" ] ; then
+                (head -c 12 /dev/urandom | ${pkgs.perl}/bin/shasum | cut -d' ' -f1) > /var/lib/faasd/secrets/basic-auth-password
+              fi
+            ''
+          }
+          echo ${cfg.basicAuth.user} > /var/lib/faasd/secrets/basic-auth-user
+
+          ln -fs "${cfg.package}/installation/prometheus.yml" "/var/lib/faasd/prometheus.yml"
+          ln -fs "${cfg.package}/installation/resolv.conf" "/var/lib/faasd/resolv.conf"
+        '';
+
+        before = [ "faasd-provider.service" "faasd.service" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+        };
       };
-    };
 
-    systemd.services.faasd = {
-      description = "faasd";
-      after = [ "faasd-provider.service" ];
-      wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.iptables ];
+      systemd.services.faasd-provider = {
+        description = "faasd-provider";
+        after = [ "network.service" "firewall.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.iptables ];
 
-      preStart = ''
-        ln -fs "${dockerComposeYaml}" "/var/lib/faasd/docker-compose.yaml"
-      '';
-
-      serviceConfig = {
-        MemoryLimit = "500M";
-        Restart = "on-failure";
-        RestartSec = "10s";
-        ExecStart = "${cfg.package}/bin/faasd up";
-        WorkingDirectory = "/var/lib/faasd";
+        serviceConfig = {
+          MemoryLimit = "500M";
+          Restart = "on-failure";
+          RestartSec = "10s";
+          Environment = [ "basic_auth=true" "secret_mount_path=/var/lib/faasd/secrets" ];
+          ExecStart = "${cfg.package}/bin/faasd provider";
+          WorkingDirectory = "/var/lib/faasd-provider";
+        };
       };
-    };
-  };
+
+      systemd.services.faasd = {
+        description = "faasd";
+        after = [ "faasd-provider.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.iptables ];
+
+        preStart = ''
+          ln -fs "${dockerComposeYaml}" "/var/lib/faasd/docker-compose.yaml"
+        '';
+
+        serviceConfig = {
+          MemoryLimit = "500M";
+          ExecStart = "${cfg.package}/bin/faasd up";
+          Restart = "on-failure";
+          RestartSec = "10s";
+          WorkingDirectory = "/var/lib/faasd";
+        };
+      };
+    })
+
+    (mkIf (cfg.namespaces != [ ]) {
+      systemd.services.faasd-create-namespaces = {
+        description = "Create OpenFaaS namespaces";
+        script = ''
+          ${concatMapStrings (namespace: ''
+            echo "Creating namespace ${namespace}"
+            ${pkgs.containerd}/bin/ctr namespace create ${namespace} || true
+            ${pkgs.containerd}/bin/ctr namespace label ${namespace} openfaas=true
+          '') cfg.namespaces}
+        '';
+
+        before = [ "faasd.service" ];
+        wantedBy = [ "multi-user.target" ];
+        after = [ "containerd.service" ];
+        requires = [ "containerd.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+        };
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## Description
Allow users to define namespaces for faasd using the `services.faasd.namespaces` option.

Namespaces are automatically created and labeled with `openfaas=true`