### PR TITLE
Support importing images from files.

### DIFF
--- a/modules/core-services/basic-auth-plugin.nix
+++ b/modules/core-services/basic-auth-plugin.nix
@@ -1,11 +1,21 @@
-{ config, lib, ... }:
+{ config, pkgs, lib, ... }:
 let
+  inherit (pkgs.dockerTools) pullImage;
+
   cfg = config.services.faasd;
+
+  basic-auth-plugin = pullImage {
+    imageName = "ghcr.io/openfaas/basic-auth";
+    imageDigest = "sha256:1785bd63d9062f8e90c65cefc07c3264855e5d0541ee766044cfdd6d66ccd580";
+    finalImageTag = "0.21.0";
+    sha256 = "sha256-en7s+NT4ByLeiT9oSIPjVT9ireXJL+n46b3vwgteJO0=";
+  };
 in
 {
   config.services.faasd.containers = lib.mkIf cfg.basicAuth.enable {
     basic-auth-plugin = {
       image = "ghcr.io/openfaas/basic-auth:0.21.0";
+      imageFile = lib.mkIf cfg.seedCoreImages basic-auth-plugin;
       environment = {
         port = 8080;
         secret_mount_path = "/run/secrets";

--- a/modules/core-services/nats.nix
+++ b/modules/core-services/nats.nix
@@ -1,8 +1,21 @@
-{ ... }:
+{ config, pkgs, lib, ... }:
+let
+  inherit (pkgs.dockerTools) pullImage;
+
+  cfg = config.services.faasd;
+
+  nats = pullImage {
+    imageName = "docker.io/library/nats-streaming";
+    imageDigest = "sha256:ba1be2cd913a1e9f1ffc9445e5c04c169db333819beb7204deb3bc7c29fde5a8";
+    finalImageTag = "0.22.0";
+    sha256 = "sha256-hUY3GAyAveHnpxHmlX9jkKQG8vzgJfuEqeNZB4bByqU=";
+  };
+in
 {
   config.services.faasd.containers = {
     nats = {
       image = "docker.io/library/nats-streaming:0.22.0";
+      imageFile = lib.mkIf cfg.seedCoreImages nats;
       command = [
         "/nats-streaming-server"
         "-m"

--- a/modules/core-services/prometheus.nix
+++ b/modules/core-services/prometheus.nix
@@ -1,8 +1,21 @@
-{ ... }:
+{ config, pkgs, lib, ... }:
+let
+  inherit (pkgs.dockerTools) pullImage;
+
+  cfg = config.services.faasd;
+
+  prometheus = pullImage {
+    imageName = "docker.io/prom/prometheus";
+    imageDigest = "sha256:907e20b3b0f8b0a76a33c088fe9827e8edc180e874bd2173c27089eade63d8b8";
+    finalImageTag = "v2.14.0";
+    sha256 = "sha256-OTGGUOPgx2k2QPG+r5kj4slOXzzs3JUwvGoKWFW4BDw=";
+  };
+in
 {
   config.services.faasd.containers = {
     prometheus = {
       image = "docker.io/prom/prometheus:v2.14.0";
+      imageFile = lib.mkIf cfg.seedCoreImages prometheus;
       volumes = [
         {
           #Config directory

--- a/modules/faasd-module.nix
+++ b/modules/faasd-module.nix
@@ -2,7 +2,7 @@
 
 let
   inherit (lib) mkOption mkIf mkMerge types concatMapStrings;
-  inherit (types) package bool str attrsOf listOf submodule nullOr;
+  inherit (types) package bool str attrsOf listOf enum submodule nullOr;
 
   cfg = config.services.faasd;
 
@@ -95,6 +95,14 @@ in
       default = [ ];
       type = listOf (submodule seedOpts);
     };
+
+    pullPolicy = mkOption {
+      description = ''
+        Set to "Always" to force a pull of images upon deployment, or "IfNotPresent" to try to use a cached image.
+      '';
+      type = enum [ "Always" "IfNotPresent" ];
+      default = "Always";
+    };
   };
 
   config = mkMerge [
@@ -162,7 +170,7 @@ in
           Restart = "on-failure";
           RestartSec = "10s";
           Environment = [ "basic_auth=${boolToString cfg.basicAuth.enable}" "secret_mount_path=/var/lib/faasd/secrets" ];
-          ExecStart = "${cfg.package}/bin/faasd provider";
+          ExecStart = "${cfg.package}/bin/faasd provider --pull-policy ${cfg.pullPolicy}";
           WorkingDirectory = "/var/lib/faasd-provider";
         };
       };

--- a/modules/faasd-module.nix
+++ b/modules/faasd-module.nix
@@ -103,6 +103,12 @@ in
       type = enum [ "Always" "IfNotPresent" ];
       default = "Always";
     };
+
+    nameserver = mkOption {
+      description = "Nameserver to use";
+      type = str;
+      default = "8.8.8.8";
+    };
   };
 
   config = mkMerge [
@@ -148,7 +154,7 @@ in
           echo ${cfg.basicAuth.user} > /var/lib/faasd/secrets/basic-auth-user
 
           ln -fs "${cfg.package}/installation/prometheus.yml" "/var/lib/faasd/prometheus.yml"
-          ln -fs "${cfg.package}/installation/resolv.conf" "/var/lib/faasd/resolv.conf"
+          echo "nameserver ${cfg.nameserver}" > "/var/lib/faasd/resolv.conf"
         '';
 
         before = [ "faasd-provider.service" "faasd.service" ];

--- a/modules/faasd-module.nix
+++ b/modules/faasd-module.nix
@@ -69,6 +69,12 @@ in
       example = [ "dev" ];
     };
 
+    seedCoreImages = mkOption {
+      description = "Seed faasd core images";
+      type = bool;
+      default = false;
+    };
+
     seedDockerImages = mkOption {
       description = "List of docker images to preload on system";
       default = [ ];

--- a/modules/service.nix
+++ b/modules/service.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib) mkOption types optionalAttrs;
-  inherit (types) listOf nullOr attrsOf str either int bool submodule;
+  inherit (lib) mkOption types optionalAttrs literalExpression;
+  inherit (types) listOf nullOr attrsOf str either int bool submodule package;
 
   link = url: text:
     ''link:${url}[${text}]'';
@@ -18,6 +18,18 @@ in
     image = mkOption {
       type = str;
       description = dockerComposeRef "image";
+    };
+
+    imageFile = mkOption {
+      type = nullOr package;
+      default = null;
+      description = ''
+        Path to an image file to load instead of pulling from a registry.
+        If defined, do not pull from registry.
+        You still need to set the <literal>image</literal> attribute, as it
+        will be used as the image name for faasd to start a container.
+      '';
+      example = literalExpression "pkgs.dockerTools.buildImage {...};";
     };
 
     depends_on = mkOption {


### PR DESCRIPTION
## Description
Support importing images from files.

- Add option: `faasd.containers.<name>.imageFile`. Allow additional faasd services to point to an image file that will be loaded on the system instead of pulling form a registry.
- Add option: `faasd.seedCoreImages`. When true core images will be imported from a file using `ctr` before starting `faasd`.
- Add option: `faasd.seedDockerImages`. This option can be used to ensure additional images are imported to the specified namespace.


## Motivation
- Nix has great support for building images. `faasd-nix` should support running extra services (and optionally functions) based of images build with nix.
- Work towards running integration tests for `faasd` and `faasd-nix`. NixOS tests should be able to run with sandboxing enabled in which case they have no internet access. Core images and function images should be pre loaded on the system.
- As a bonus this could simplify running `faasd` on an air gapped NixOS system.

## Examples
- Seed core images
```nix
{  services.faasd.seedCoreImages = true; }
```
- Seed additional docker images
```nix
{ pkgs, ... }:
  let
    figlet = pkgs.dockerTools.pullImage {
      imageName = "ghcr.io/openfaas/figlet";
      imageDigest = "sha256:98b7e719cabe654a7d2f8ff0f3c11294ef737a1f1e4eeef7321277420dfebe8d";
      finalImageTag = "latest";
      sha256 = "sha256-leYfLXQ4cCvPOudU82UaV9BkUIA+W6YvM0zx3BlyCjw=";
    };
  in
  {
    services.faasd = {
      enable = true;
      seedCoreImages = true;
      seedDockerImages = [
        {
          namespace = "openfaas-fn";
          imageFile = figlet;
        }
      ];
    };
  }

```