### PR TITLE
Add dockerComposeFile option

### DIFF
--- a/modules/faasd-module.nix
+++ b/modules/faasd-module.nix
@@ -48,6 +48,16 @@ in
       default = pkgs.faasd;
     };
 
+    dockerComposeFile = mkOption {
+      description = ''
+        Path to docker-compose.yaml.
+
+        By setting this all options related to faasd services will be ignored and the docker-compose configuration will be used instead.
+      '';
+      type = nullOr str;
+      default = null;
+    };
+
     basicAuth = {
       enable = mkOption {
         description = "Enable basicAuth";
@@ -188,7 +198,11 @@ in
         path = [ pkgs.iptables ];
 
         preStart = ''
-          ln -fs "${dockerComposeYaml}" "/var/lib/faasd/docker-compose.yaml"
+          ${if (cfg.dockerComposeFile != null ) then 
+            ''ln -fs ${cfg.dockerComposeFile} /var/lib/faasd/docker-compose.yaml''
+          else
+            ''ln -fs ${dockerComposeYaml} /var/lib/faasd/docker-compose.yaml''
+          }
         '';
 
         serviceConfig = {


### PR DESCRIPTION
## Description
Allow the generated docker-compose file to be overridden.

## Motivation
Useful when using faasd-nix to test faasd during development.

## Examples
- Use the source docker-compose file.
```nix
{ services.faasd.dockerComposeFile = "${pkgs.faasd}/installation/docker-compose.yaml"; }
```