### PR TITLE
Run NixOS integration tests in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,3 +28,5 @@ jobs:
             .#queue-worker-image \
             .#nats-image \
             .#prometheus-image
+      - name: Check flake
+        run: nix flake check -L --accept-flake-config

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,8 @@ jobs:
           name: welteki
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: true
+      - name: Check flake
+        run: nix flake check -L --accept-flake-config
       - name: Build faasd 🔧
         run: |
           nix build -L .#faasd


### PR DESCRIPTION
## Description

KVM is now available on GitHub action runners. The [Determinate Nix Installer Action](https://github.com/DeterminateSystems/nix-installer-action) enables KVM by default.

Run `nix flake check` which runs NixOS intergration tests for faasd in the GitHub actions workflows. 
